### PR TITLE
fix(magneto) : #MAG-419 fix share folder not being put in CRNA theme color.

### DIFF
--- a/overrides/na/css/styles/_magneto.scss
+++ b/overrides/na/css/styles/_magneto.scss
@@ -37,7 +37,7 @@ body.magneto {
       background: $primary-lighter;
     }
     &-infos {
-      i.magneto-folder {
+      i.magneto-folder, i.magneto-folder-share {
         color: $primary;
       }
     }


### PR DESCRIPTION
Fix share folder not being put in CRNA theme color (was blue when it was supposed to be red).

![image](https://github.com/OPEN-ENT-NG/theme-open-ent/assets/23381150/0f2deae1-d848-4627-8a5e-bfd78cca5dfd)
